### PR TITLE
Add description, extract name and description from file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .stravaupload.cfg
+*.fit
+*.tcx
+*.gpx
+*.gz

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # stravaupload
-Small python script to upload tcs files to strava. It is intended for personal use and has a lot of limitations. Feel free to use it however you like. If you have any comments, questions or want to help, dont hasitate to contact me.
+Small Python script to upload FIT, TCX and GPX (and .fit.gz, .tcx.gz, .gpx.gz) files to Strava. It is intended for personal use and has a lot of limitations. Feel free to use it however you like. If you have any comments, questions or want to help, dont hesitate to contact me.
 
-Tips: You can use the script https://github.com/marthinsen/polar2tcx to create tcx files from Polar devices.
+Tips: You can use the [polar2tcx script](https://github.com/marthinsen/polar2tcx) to create TCX files from Polar devices.
 
 ## Requirements
-You need python with stravalib (https://github.com/hozn/stravalib) installed (pip install stravalib)
+You need Python with [stravalib](https://github.com/hozn/stravalib) installed: `pip install stravalib`
 
 ## Instructions
-1. Create an Strava Application and follow the instructions here: http://strava.github.io/api/v3/oauth/ to get an access token.
-2. Rename the file .stravalib.cfg.sample to .stravalib.cfg and enter the access token there.
-3. Run the script by ./stravaupload.py
-
+1. Create a Strava application and follow the instructions here: http://strava.github.io/api/v3/oauth/ to get an access token.
+2. Rename the file .stravalib.cfg.sample to .stravalib.cfg (or ~/.stravaupload.cfg') and enter the access token there.
+3. Run the script by `./stravaupload.py`

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ except ImportError:
 
 setup(name='StravaUpload',
       version='1.0',
-      description='Upload tcs files to Strava',
+      description='Upload files to Strava',
       author='Eirik Marthinsen',
       author_email='eirikma@gmail.com',
       url='https://github.com/marthinsen/stravaupload',

--- a/stravaupload.py
+++ b/stravaupload.py
@@ -37,6 +37,7 @@ def main():
     parser = ArgumentParser(description='Upload files to Strava')
     parser.add_argument('input', help='Input filename')
     parser.add_argument('-t', '--title', help='Title of activity')
+    parser.add_argument('-d', '--description', help='Description of activity')
     parser.add_argument('-p', '--private', action='store_true',
                         help='Make the activity private')
     parser.add_argument('-a', '--activity', choices=model.Activity.TYPES,
@@ -78,6 +79,7 @@ def main():
             activity_file=open(args.input, 'r'),
             data_type=data_type,
             name=args.title,
+            description=args.description,
             private=True if args.private else False,
             activity_type=activity_type
         )

--- a/stravaupload.py
+++ b/stravaupload.py
@@ -36,7 +36,6 @@ def name_and_description_from_file(filename):
 
     if filename.endswith('.gpx') or filename.endswith('.gpx.gz'):
         import gpxpy
-        import gpxpy.gpx
 
         if filename.endswith('.gpx.gz'):
             import gzip
@@ -47,7 +46,6 @@ def name_and_description_from_file(filename):
         elif filename.endswith('.gpx'):
             with open(filename) as gpx_data:
                 gpx = gpxpy.parse(gpx_data)
-                return gpx.name, gpx.description
 
         return gpx.name, gpx.description
 

--- a/stravaupload.py
+++ b/stravaupload.py
@@ -53,6 +53,7 @@ def name_and_description_from_file(filename):
 
     return None, None
 
+
 def main():
     """Main function
     """

--- a/stravaupload.py
+++ b/stravaupload.py
@@ -19,7 +19,7 @@ def data_type_from_filename(filename):
 
     data_type = None
 
-    for ext in ['.fit','.fit.gz', '.tcx', '.tcx.gz', '.gpx', '.gpx.gz']:
+    for ext in ['.fit', '.fit.gz', '.tcx', '.tcx.gz', '.gpx', '.gpx.gz']:
         if filename.endswith(ext):
             data_type = ext.lstrip('.')
 

--- a/stravaupload.py
+++ b/stravaupload.py
@@ -29,6 +29,30 @@ def data_type_from_filename(filename):
     return data_type
 
 
+def name_and_description_from_file(filename):
+    """Find the name and description from GPX files.
+    Other files not yet supported.
+    """
+
+    if filename.endswith('.gpx') or filename.endswith('.gpx.gz'):
+        import gpxpy
+        import gpxpy.gpx
+
+        if filename.endswith('.gpx.gz'):
+            import gzip
+            with gzip.open(filename) as info:
+                gpx_data = info.read()
+            gpx = gpxpy.parse(gpx_data)
+
+        elif filename.endswith('.gpx'):
+            with open(filename) as gpx_data:
+                gpx = gpxpy.parse(gpx_data)
+                return gpx.name, gpx.description
+
+        return gpx.name, gpx.description
+
+    return None, None
+
 def main():
     """Main function
     """
@@ -71,6 +95,14 @@ def main():
 
     # Find the data type
     data_type = data_type_from_filename(args.input)
+
+    # Extract name and description from the file
+    if not args.title or not args.description:
+        name, description = name_and_description_from_file(args.input)
+    if not args.title:
+        args.title = name
+    if not args.description:
+        args.description = description
 
     # Try to upload
     print 'Uploading...'

--- a/stravaupload.py
+++ b/stravaupload.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-""" Upload tcx files to Strava
+""" Upload files to Strava
 """
 
 import sys
@@ -12,13 +12,30 @@ from ConfigParser import SafeConfigParser
 from stravalib import Client, exc, model
 
 
+def data_type_from_filename(filename):
+    """Return the data type from the filename's extension.
+    Exit if not supported.
+    """
+
+    data_type = None
+
+    for ext in ['.fit','.fit.gz', '.tcx', '.tcx.gz', '.gpx', '.gpx.gz']:
+        if filename.endswith(ext):
+            data_type = ext.lstrip('.')
+
+    if not data_type:
+        exit('Extension not supported')
+
+    return data_type
+
+
 def main():
     """Main function
     """
 
     # Parse the input arguments
-    parser = ArgumentParser(description='Upload tcx file to Strava')
-    parser.add_argument('input', help='Input tcx file')
+    parser = ArgumentParser(description='Upload files to Strava')
+    parser.add_argument('input', help='Input filename')
     parser.add_argument('-t', '--title', help='Title of activity')
     parser.add_argument('-p', '--private', action='store_true',
                         help='Make the activity private')
@@ -51,12 +68,15 @@ def main():
     strava = Client()
     strava.access_token = access_token
 
+    # Find the data type
+    data_type = data_type_from_filename(args.input)
+
     # Try to upload
     print 'Uploading...'
     try:
         upload = strava.upload_activity(
             activity_file=open(args.input, 'r'),
-            data_type='tcx',
+            data_type=data_type,
             name=args.title,
             private=True if args.private else False,
             activity_type=activity_type


### PR DESCRIPTION
- Includes PR #1.
- Adds a description parameter.
- For .gpx and .gpx.gz files, if name or description parameters are missing, extracts them from the file.

That last bit requires [gpxpy](https://github.com/tkrajina/gpxpy) (`pip install gpxpy`), but only for .gpx and .gpx.gz files if there's no name/description.
